### PR TITLE
Error name changed from 'Error' to constructor name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
 .DS_Store
 *.log
 /node_modules
+package-lock.json

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,9 @@
 
 function BaseError(message) {
     this.message = message || "";
+    if(this.constructor.name) {
+        this.name = this.constructor.name;
+    }
     if (Error.captureStackTrace) {
         // V8 stack trace capture.
         Error.captureStackTrace(this, this.constructor);

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -4,7 +4,7 @@ const BaseError = require("../lib/index")["default"];
 
 describe("BaseError", () => {
 
-    class TestError extends BaseError {};
+    class TestError extends BaseError {}
 
     const testError = new TestError("foo");
 
@@ -24,7 +24,7 @@ describe("BaseError", () => {
     });
 
     it("provides a toString() implementation", () => {
-        expect(testError.toString()).to.equal("Error: foo");
+        expect(testError.toString()).to.equal(`${TestError.name}: foo`);
     });
 
 });

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -23,8 +23,21 @@ describe("BaseError", () => {
         expect(testError.message).to.equal("foo");
     });
 
-    it("provides a toString() implementation", () => {
+    it("provides a toString() implementation (with constructor name as error name)", () => {
         expect(testError.toString()).to.equal(`${TestError.name}: foo`);
+    });
+
+    it("provides a toString() implementation (with overridden error name)", () => {
+        const ERROR_NAME = 'SpecialError';
+        class TestErrorWithOverriddenErrorName extends BaseError {
+            constructor(message) {
+                super(message);
+                this.name = ERROR_NAME;
+            }
+        }
+        const specialError = new TestErrorWithOverriddenErrorName('foo');
+
+        expect(specialError.toString()).to.equal(`${ERROR_NAME}: foo`);
     });
 
 });


### PR DESCRIPTION
Since ES6 `Function.name` is part of the specification. To create a more meaningful string representation of an error, the name of the constructor is now used automatically as the name of the error. So when an error `TestError` (which of course extends `BaseError`) is thrown, it prints `TestError: foo` instead of `Error: foo`.

@etianen What do you think about it? 